### PR TITLE
Forward compatibility with voryx/event-loop 3.0 and while supporting 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     }
   },
   "require": {
-    "voryx/event-loop": "^2.0",
+    "voryx/event-loop": "^3.0 || ^2.0",
     "react/child-process": "^0.4.3",
     "reactivex/rxphp": "^2.0"
   },


### PR DESCRIPTION
As promised at https://github.com/voryx/event-loop/pull/1#issuecomment-382123772 here is the PR that updates this package to support voryx/event-loop 3.0 and 2.0.